### PR TITLE
Fix 2 null checks

### DIFF
--- a/src/scripts/layer-hotkeys.js
+++ b/src/scripts/layer-hotkeys.js
@@ -197,7 +197,7 @@ export default function () {
       const li = scene_control[i];
       let title = li.getAttribute("title");
       let key = config.layer[li.getAttribute("data-control")];
-      if (key !== undefined) li.title += " [" + key.toUpperCase() + "]";
+      if (key !== undefined && key !== null) li.title += " [" + key.toUpperCase() + "]";
       let ctrls = li.getElementsByClassName("control-tool");
       for (let j = 0; j < ctrls.length; j++) {
         let title = ctrls[j].title + " [" + config.tool[j + 1] + "]";

--- a/src/scripts/layer-hotkeys.js
+++ b/src/scripts/layer-hotkeys.js
@@ -85,7 +85,7 @@ export default function () {
           const key = window.Azzu.SettingsTypes.KeyBinding.parse(
             CONFIG["layer-hotkeys"].layer[control.name]
           );
-          if (window.Azzu.SettingsTypes.KeyBinding.eventIsForBinding(ev, key)) {
+          if (key && window.Azzu.SettingsTypes.KeyBinding.eventIsForBinding(ev, key)) {
             ev.preventDefault();
             ev.stopPropagation();
             canvas.getLayer(control.layer).activate();
@@ -197,7 +197,7 @@ export default function () {
       const li = scene_control[i];
       let title = li.getAttribute("title");
       let key = config.layer[li.getAttribute("data-control")];
-      if (key !== undefined && key !== null) li.title += " [" + key.toUpperCase() + "]";
+      if (key) li.title += " [" + key.toUpperCase() + "]";
       let ctrls = li.getElementsByClassName("control-tool");
       for (let j = 0; j < ctrls.length; j++) {
         let title = ctrls[j].title + " [" + config.tool[j + 1] + "]";


### PR DESCRIPTION
1. Line 88 causing:
```js
Uncaught TypeError: Cannot read property 'ctrlKey' of null
    at settings-extender.js:89
    at Array.reduce (<anonymous>)
    at t (settings-extender.js:88)
    at i (settings-extender.js:97)
    at Function.s.eventIsForBinding (settings-extender.js:206)
    at window.addEventListener.useCapture (layer-hotkeys.js:88)
```

2. Line 200 causing:
```js
TypeError: Cannot read property 'toUpperCase' of null
    at layer-hotkeys.js:200
    at Function._call (foundry.js:2496)
    at Function.call (foundry.js:2481)
    at SceneControls._render (foundry.js:4547)
```